### PR TITLE
Use AWSKMSClientBuilder

### DIFF
--- a/src/examples/java/com/amazonaws/crypto/examples/BuilderExample.java
+++ b/src/examples/java/com/amazonaws/crypto/examples/BuilderExample.java
@@ -1,0 +1,71 @@
+package com.amazonaws.crypto.examples;
+
+import com.amazonaws.encryptionsdk.AwsCrypto;
+import com.amazonaws.encryptionsdk.CryptoResult;
+import com.amazonaws.encryptionsdk.kms.KmsMasterKey;
+import com.amazonaws.encryptionsdk.kms.KmsMasterKeyProvider;
+import com.amazonaws.encryptionsdk.kms.KmsMasterKeyProviderBuilder;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * <p>
+ * Encrypts and then decrypts a string under a KMS key
+ *
+ * <p>
+ * Arguments:
+ * <ol>
+ * <li>KMS Key Arn
+ * <li>String to encrypt
+ * </ol>
+ */
+public class BuilderExample {
+
+    private static String keyArn;
+    private static String data;
+
+    public static void main(final String[] args) {
+        keyArn = args[0];
+        data = args[1];
+
+        // Instantiate the SDK
+        final AwsCrypto crypto = new AwsCrypto();
+
+        // Set up the KmsMasterKeyProvider using the defaults provided by the KmsMasterKeyProviderBuilder
+        final KmsMasterKeyProvider prov = KmsMasterKeyProviderBuilder.standard()
+                .withKeyId(keyArn)
+                .build();
+
+        // Encrypt the data
+        //
+        // Most encrypted data should have associated encryption context
+        // to protect integrity. Here, we'll just use a placeholder value.
+        //
+        // For more information see:
+        // blogs.aws.amazon.com/security/post/Tx2LZ6WBJJANTNW/How-to-Protect-the-Integrity-of-Your-Encrypted-Data-by-Using-AWS-Key-Management
+        final Map<String, String> context = Collections.singletonMap("Example", "String");
+
+        final String ciphertext = crypto.encryptString(prov, data, context).getResult();
+        System.out.println("Ciphertext: " + ciphertext);
+
+        // Decrypt the data
+        final CryptoResult<String, KmsMasterKey> decryptResult = crypto.decryptString(prov, ciphertext);
+        // We need to check the encryption context (and ideally key) to ensure that
+        // this was the ciphertext we expected
+        if (!decryptResult.getMasterKeyIds().get(0).equals(keyArn)) {
+            throw new IllegalStateException("Wrong key id!");
+        }
+
+        // The SDK may add information to the encryption context, so we check to ensure
+        // that all of our values are present
+        for (final Map.Entry<String, String> e : context.entrySet()) {
+            if (!e.getValue().equals(decryptResult.getEncryptionContext().get(e.getKey()))) {
+                throw new IllegalStateException("Wrong Encryption Context!");
+            }
+        }
+
+        // Now that we know we have the correct data, we can output it.
+        System.out.println("Decrypted: " + decryptResult.getResult());
+    }
+}

--- a/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
@@ -131,7 +131,12 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
         kms_ = kms;
         region_ = region;
         regionName_ = region.getName();
-        kms_.setRegion(region);
+        // When kms_ is created by the builder, it is immutable and will throw an exception when setting something
+        try {
+            kms_.setRegion(region);
+        } catch (UnsupportedOperationException e) {
+            // Ignored. Not a problem, region should already be set by the builder.
+        }
         keyIds_ = new ArrayList<>(keyIds);
     }
 
@@ -244,7 +249,7 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
         return region_;
     }
 
-    private static Region getStartingRegion(final String keyArn) {
+    static Region getStartingRegion(final String keyArn) {
         final String region = parseRegionfromKeyArn(keyArn);
         if (region != null) {
             return Region.getRegion(Regions.fromName(region));

--- a/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
@@ -140,6 +140,10 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
         keyIds_ = new ArrayList<>(keyIds);
     }
 
+    public static KmsMasterKeyProviderBuilder builder() {
+        return KmsMasterKeyProviderBuilder.standard();
+    }
+
     /**
      * Returns "aws-kms"
      */

--- a/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
@@ -220,6 +220,8 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
      * Configures this provider to use a custom endpoint. Sets the underlying {@link Region} object
      * to {@code null}, and instructs the internal KMS client to use the specified {@code endPoint}
      * and {@code regionName}.
+     *
+     * Note: This method will not work if this object was created by {@link KmsMasterKeyProviderBuilder}.
      */
     public void setCustomEndpoint(final String regionName, final String endPoint) {
         if (kms_ instanceof AWSKMSClient) {
@@ -235,6 +237,8 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
     /**
      * Set the AWS region of the AWS KMS service for access to the master key. This method simply
      * calls the same method of the underlying {@link AWSKMSClient}
+     *
+     * Note: This method will not work if this object was created by {@link KmsMasterKeyProviderBuilder}.
      *
      * @param region
      *            string containing the region.

--- a/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProviderBuilder.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProviderBuilder.java
@@ -27,7 +27,7 @@ import java.util.List;
  * Example, specifying a region:
  * <pre>
  *     KmsMasterKeyProvider keyProvider = KmsMasterKeyProviderBuilder.standard()
- *       .withRegion("us-east-1")
+ *       .withDefaultRegion("us-east-1")
  *       .build();
  * </pre>
  */
@@ -54,9 +54,9 @@ public class KmsMasterKeyProviderBuilder extends AwsClientBuilder<KmsMasterKeyPr
     }
 
     /**
-     * Sets the region to be used by the client. Overrides any previously set region.
+     * Sets the default region to be used by the client. Overrides any previously set region.
      */
-    public KmsMasterKeyProviderBuilder withRegion(Region region) {
+    public KmsMasterKeyProviderBuilder withDefaultRegion(Region region) {
         return withRegion(region.getName());
     }
 
@@ -66,7 +66,7 @@ public class KmsMasterKeyProviderBuilder extends AwsClientBuilder<KmsMasterKeyPr
     public KmsMasterKeyProviderBuilder withKeyId(String keyId) {
         withKeyIds(Collections.singletonList(keyId));
 
-        withRegion(KmsMasterKeyProvider.getStartingRegion(keyId));
+        withDefaultRegion(KmsMasterKeyProvider.getStartingRegion(keyId));
 
         return this;
     }

--- a/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProviderBuilder.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProviderBuilder.java
@@ -1,0 +1,128 @@
+package com.amazonaws.encryptionsdk.kms;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.RegionUtils;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.kms.AWSKMSClient;
+import com.amazonaws.services.kms.AWSKMSClientBuilder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Used to build a {@link KmsMasterKeyProvider} using {@link AWSKMSClientBuilder}, which will use provider chains to get
+ * defaults if the properties are not explicitly set.
+ *
+ * Default usage will use all the defaults found by AWSKMSClientBuilder. If a region is not found in the configuration
+ * chain, then {@link Regions#DEFAULT_REGION} is used.
+ * <pre>
+ *     KmsMasterKeyProvider keyProvider = KmsMasterKeyProviderBuilder.defaultProvider();
+ * </pre>
+ *
+ * Example, specifying a region:
+ * <pre>
+ *     KmsMasterKeyProvider keyProvider = KmsMasterKeyProviderBuilder.standard()
+ *       .withRegion("us-east-1")
+ *       .build();
+ * </pre>
+ */
+public class KmsMasterKeyProviderBuilder {
+
+    private AWSKMSClientBuilder clientBuilder;
+    private List<String> keyIds;
+
+    /**
+     * @return a new {@link KmsMasterKeyProviderBuilder} with the defaults set.
+     */
+    public static KmsMasterKeyProviderBuilder standard() {
+        return new KmsMasterKeyProviderBuilder();
+    }
+
+    /**
+     * @return a KmsMasterKeyProvider using the {@link AWSKMSClientBuilder} defaults, and an empty key ID list.
+     */
+    public static KmsMasterKeyProvider defaultProvider() {
+        return standard().build();
+    }
+
+    private KmsMasterKeyProviderBuilder() {
+        clientBuilder = AWSKMSClientBuilder.standard();
+    }
+
+    /**
+     * Sets the region to be used by the client. Overrides any previously set region.
+     */
+    public KmsMasterKeyProviderBuilder withRegion(Region region) {
+        return withRegion(region.getName());
+    }
+
+    /**
+     * Sets the region to be used by the client. Overrides any previously set region.
+     */
+    public KmsMasterKeyProviderBuilder withRegion(String regionName) {
+        clientBuilder.withRegion(regionName);
+        return this;
+    }
+
+    /**
+     * Sets the client configuration to use.
+     */
+    public KmsMasterKeyProviderBuilder withClientConfiguration(ClientConfiguration clientConfiguration) {
+        clientBuilder.withClientConfiguration(clientConfiguration);
+        return this;
+    }
+
+    /**
+     * Sets the credentials to use.
+     */
+    public KmsMasterKeyProviderBuilder withCredentials(AWSCredentialsProvider credentialsProvider) {
+        clientBuilder.withCredentials(credentialsProvider);
+        return this;
+    }
+
+    /**
+     * Sets the region using a keyId. This will override any previously set regions.
+     */
+    public KmsMasterKeyProviderBuilder withKeyId(String keyId) {
+        withKeyIds(Collections.singletonList(keyId));
+
+        withRegion(KmsMasterKeyProvider.getStartingRegion(keyId));
+
+        return this;
+    }
+
+    /**
+     * Adds {@code keyIds}, but does not use them to set the region.
+     */
+    public KmsMasterKeyProviderBuilder withKeyIds(List<String> keyIds) {
+        if (this.keyIds == null) {
+            this.keyIds = new ArrayList<>();
+        }
+
+        this.keyIds.addAll(keyIds);
+
+        return this;
+    }
+
+    /**
+     * Builds the {@link KmsMasterKeyProvider} using the information it was built with or {@link AWSKMSClientBuilder}'s
+     * defaults.
+     */
+    public KmsMasterKeyProvider build() {
+        keyIds = (keyIds == null) ? Collections.emptyList() : keyIds;
+
+        String clientBuilderRegion = clientBuilder.getRegion();
+
+        String regionName = (clientBuilderRegion == null) ? Regions.DEFAULT_REGION.getName()
+                : clientBuilderRegion;
+
+        clientBuilder = clientBuilder.withRegion(regionName);
+
+        return new KmsMasterKeyProvider((AWSKMSClient) clientBuilder.build(),
+                RegionUtils.getRegion(regionName),
+                keyIds);
+    }
+}


### PR DESCRIPTION
I decided to make a new `KmsMasterKeyProviderBuilder` class instead of just using the builder directly inside `KmsMasterKeyProvider`. There are two reasons for this:
1. The motivation behind the client builders in the AWS Java SDK was to remove the need to have/use multiple constructors to build an object, and I felt it would be valuable to carry that reasoning over to this library. Using the builder removes the need to search for the correct constructor, and is a bit more expressive.
2. A separate builder class ensures that code previously written using the old constructors will not break with the introduction of the client builders. I noticed that clients created with the builder are immutable, so any calls to the setters in `KmsMasterKeyProvider` that change the state of the KMS client (e.g. `KmsMasterKeyProvider#setRegion`), will throw an exception, and won't change as expected. This way felt safer.

Also, feel free to share thoughts on how the new builder can be tested. I originally added an `equals` method to KmsMasterKeyProvider, and was going to ensure that both the builder and constructor created objects with the same properties, but because `AWSKMSClient` does not have `equals` overriden, this proved to be difficult.
