### PR TITLE
Make estimateCiphertextSize work with cached keys

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
@@ -171,6 +171,10 @@ public class AwsCrypto {
         EncryptionMaterialsRequest request = EncryptionMaterialsRequest.newBuilder()
                                                                        .setContext(encryptionContext)
                                                                        .setRequestedAlgorithm(getEncryptionAlgorithm())
+        // We're not actually encrypting any data, so don't consume any bytes from the cache's limits. We do need to
+        // pass /something/ though, or the cache will be bypassed (as it'll assume this is a streaming encrypt of
+        // unknown size).
+                                                                       .setPlaintextSize(0)
                                                                        .build();
 
         final MessageCryptoHandler cryptoHandler = new EncryptionHandler(


### PR DESCRIPTION
estimateCiphertextSize was not passing a plaintext size down to the CMM, so the
caching CMM assumed that a streaming encryption of unknown size was being
performed, and bypassed the cache entirely.

This change passes a plaintext size of zero instead to allow cached keys to be
used; since we don't actually encrypt any data it's safe to not consume any of
the byte limit.

Note that this may not behave quite right if the CMM does more clever things
with plaintext size. In general we should probably resolve this by moving
estimateCiphertextSize over to the Cipher*Stream objects instead, where it can
know the actual DataKeys in use instead of hoping they're reasonably
consistently sized.

Fixes: #29