### PR TITLE
Remove frame-size restrictions.

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
@@ -137,11 +137,7 @@ public class AwsCrypto {
         if (frameSize < 0) {
             throw new IllegalArgumentException("frameSize must be non-negative");
         }
-        if (frameSize % 16 != 0) {
-            // For compatibility reasons we'll still enforce this restriction for now.
-            // TODO: Investigate whether this can be removed.
-            throw new IllegalArgumentException("frameSize must be a multiple of 16");
-        }
+
         encryptionFrameSize_ = frameSize;
     }
 

--- a/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoTest.java
@@ -145,9 +145,7 @@ public class AwsCryptoTest {
     @Test
     public void encryptDecrypt() {
         for (final CryptoAlgorithm cryptoAlg : EnumSet.allOf(CryptoAlgorithm.class)) {
-            final int blockSize = cryptoAlg.getBlockSize();
-            final int[] frameSizeToTest = { 0, blockSize, blockSize * 2, blockSize * 10,
-                    AwsCrypto.getDefaultFrameSize() };
+            final int[] frameSizeToTest = TestUtils.getFrameSizesToTest(cryptoAlg);
 
             for (int i = 0; i < frameSizeToTest.length; i++) {
                 final int frameSize = frameSizeToTest[i];
@@ -175,9 +173,7 @@ public class AwsCryptoTest {
             if (cryptoAlg.getTrailingSignatureAlgo() == null) {
                 continue;
             }
-            final int blockSize = cryptoAlg.getBlockSize();
-            final int[] frameSizeToTest = { 0, blockSize, blockSize * 2, blockSize * 10,
-                    AwsCrypto.getDefaultFrameSize() };
+            final int[] frameSizeToTest = TestUtils.getFrameSizesToTest(cryptoAlg);
 
             for (int i = 0; i < frameSizeToTest.length; i++) {
                 final int frameSize = frameSizeToTest[i];
@@ -202,9 +198,7 @@ public class AwsCryptoTest {
     @Test
     public void encryptDecryptWithParsedCiphertext() {
         for (final CryptoAlgorithm cryptoAlg : EnumSet.allOf(CryptoAlgorithm.class)) {
-            final int blockSize = cryptoAlg.getBlockSize();
-            final int[] frameSizeToTest = { 0, blockSize, blockSize * 2, blockSize * 10,
-                    AwsCrypto.getDefaultFrameSize() };
+            final int[] frameSizeToTest = TestUtils.getFrameSizesToTest(cryptoAlg);
 
             for (int i = 0; i < frameSizeToTest.length; i++) {
                 final int frameSize = frameSizeToTest[i];
@@ -336,9 +330,7 @@ public class AwsCryptoTest {
     @Test
     public void estimateCiphertextSize() {
         for (final CryptoAlgorithm cryptoAlg : EnumSet.allOf(CryptoAlgorithm.class)) {
-            final int blockSize = cryptoAlg.getBlockSize();
-            final int[] frameSizeToTest = { 0, blockSize, blockSize * 2, blockSize * 10,
-                    AwsCrypto.getDefaultFrameSize() };
+            final int[] frameSizeToTest = TestUtils.getFrameSizesToTest(cryptoAlg);
 
             for (int i = 0; i < frameSizeToTest.length; i++) {
                 final int frameSize = frameSizeToTest[i];
@@ -664,10 +656,12 @@ public class AwsCryptoTest {
         assertEquals(setFrameSize, getFrameSize);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void unalignedFrameSizesAreRejected() throws IOException {
+
+    public void unalignedFrameSizesAreAccepted() throws IOException {
         final int frameSize = AwsCrypto.getDefaultCryptoAlgorithm().getBlockSize() - 1;
         encryptionClient_.setEncryptionFrameSize(frameSize);
+
+        assertEquals(frameSize, encryptionClient_.getEncryptionFrameSize());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/amazonaws/encryptionsdk/CryptoInputStreamTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/CryptoInputStreamTest.java
@@ -158,11 +158,7 @@ public class CryptoInputStreamTest {
             boolean firstAlgorithm = true;
 
             for (final CryptoAlgorithm cryptoAlg : EnumSet.allOf(CryptoAlgorithm.class)) {
-                final int blockSize = cryptoAlg.getBlockSize();
-                final int[] frameSizeToTest = {
-                        0, blockSize, blockSize * 2, blockSize * 10,
-                        AwsCrypto.getDefaultFrameSize()
-                };
+                final int[] frameSizeToTest = TestUtils.getFrameSizesToTest(cryptoAlg);
 
                 // Our bytesToTest and readLenVals arrays tend to have the bigger numbers towards the end - we'll chop off
                 // the last few as they take the longest and don't really add that much more coverage.

--- a/src/test/java/com/amazonaws/encryptionsdk/CryptoOutputStreamTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/CryptoOutputStreamTest.java
@@ -155,9 +155,7 @@ public class CryptoOutputStreamTest {
             ArrayList<Object[]> cases = new ArrayList<>();
 
             for (final CryptoAlgorithm cryptoAlg : EnumSet.allOf(CryptoAlgorithm.class)) {
-                final int blockSize = cryptoAlg.getBlockSize();
-                final int[] frameSizeToTest = { 0, blockSize, blockSize * 2, blockSize * 10,
-                                                AwsCrypto.getDefaultFrameSize() };
+              final int[] frameSizeToTest = TestUtils.getFrameSizesToTest(cryptoAlg);
 
                 // iterate over frame size to test
                 for (int i = 0; i < frameSizeToTest.length; i++) {

--- a/src/test/java/com/amazonaws/encryptionsdk/TestUtils.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/TestUtils.java
@@ -159,4 +159,19 @@ public class TestUtils {
     public static ByteArrayInputStream insecureRandomStream(int length) {
         return new ByteArrayInputStream(ensureRandomCached(length), 0, length);
     }
+
+    public static int[] getFrameSizesToTest(final CryptoAlgorithm cryptoAlg) {
+      final int blockSize = cryptoAlg.getBlockSize();
+      final int[] frameSizeToTest = {
+          0,
+          blockSize - 1,
+          blockSize,
+          blockSize + 1,
+          blockSize * 2,
+          blockSize * 10,
+          blockSize * 10 + 1,
+          AwsCrypto.getDefaultFrameSize()
+      };
+      return frameSizeToTest;
+  }
 }


### PR DESCRIPTION
Issue #42

The purpose of this is to remove unneeded frame-size restriction on encrypt. Decrypt has never enforced these restrictions. (So ciphertexts created by this new version will be decryptable by all old versions as well, even in other languages.)

All tests pass on my development box.