### PR TITLE
Fix FrameEncryptionHandlerVeryLongTest so that last frame is final.

### DIFF
--- a/src/test/java/com/amazonaws/encryptionsdk/internal/FrameEncryptionHandlerVeryLongTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/internal/FrameEncryptionHandlerVeryLongTest.java
@@ -43,7 +43,11 @@ public class FrameEncryptionHandlerVeryLongTest {
             expectedNonce.putInt(0);
             expectedNonce.putLong(i);
 
-            frameEncryptionHandler_.processBytes(buf, 0, 1, buf, 0);
+            if (i != Constants.MAX_FRAME_NUMBER) {
+                frameEncryptionHandler_.processBytes(buf, 0, 1, buf, 0);
+            } else {
+                frameEncryptionHandler_.doFinal(buf, 0);
+            }
 
             CipherFrameHeaders headers = new CipherFrameHeaders();
             headers.setNonceLength(algorithm.getNonceLen());


### PR DESCRIPTION
This test is currently failing (and only runs when attempting release to Maven). The problem is that the library rejects the frame with a maximum index unless it is also a final frame. This fixes that.