### PR TITLE
Fix bare aliases not using default region

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
@@ -450,6 +450,11 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
         }
 
         String regionName = parseRegionfromKeyArn(keyId);
+
+        if (regionName == null && defaultRegion_ != null) {
+            regionName = defaultRegion_;
+        }
+
         AWSKMS kms = regionalClientSupplier_.getClient(regionName);
         if (kms == null) {
             throw new AwsCryptoException("Can't use keys from region " + regionName);


### PR DESCRIPTION
The default region was not actually being consulted when presented with a
regionless key ID (such as a bare UUID or an "alias/foo" value). Fixes #50.