### PR TITLE
Make JceMasterKey Case Insensitive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 .project
 .classpath
 /bin/
+.idea/

--- a/src/main/java/com/amazonaws/encryptionsdk/jce/JceMasterKey.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/jce/JceMasterKey.java
@@ -72,8 +72,8 @@ public abstract class JceMasterKey extends MasterKey<JceMasterKey> {
      */
     public static JceMasterKey getInstance(final SecretKey key, final String provider, final String keyId,
             final String wrappingAlgorithm) {
-        switch (wrappingAlgorithm) {
-            case "AES/GCM/NoPadding":
+        switch (wrappingAlgorithm.toUpperCase()) {
+            case "AES/GCM/NOPADDING":
                 return new AesGcm(key, provider, keyId);
             default:
                 throw new IllegalArgumentException("Right now only AES/GCM/NoPadding is supported");

--- a/src/test/java/com/amazonaws/encryptionsdk/AllTestsSuite.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/AllTestsSuite.java
@@ -1,5 +1,6 @@
 package com.amazonaws.encryptionsdk;
 
+import com.amazonaws.encryptionsdk.jce.JceMasterKeyTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -52,7 +53,8 @@ import com.amazonaws.services.kms.KMSProviderBuilderMockTests;
         LocalCryptoMaterialsCacheThreadStormTest.class,
         UtilsTest.class,
         MultipleMasterKeyTest.class,
-        KMSProviderBuilderMockTests.class
+        KMSProviderBuilderMockTests.class,
+        JceMasterKeyTest.class
 })
 public class AllTestsSuite {
 }

--- a/src/test/java/com/amazonaws/encryptionsdk/jce/JceMasterKeyTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/jce/JceMasterKeyTest.java
@@ -1,0 +1,30 @@
+package com.amazonaws.encryptionsdk.jce;
+
+import org.junit.Test;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+public class JceMasterKeyTest {
+
+    private static final SecretKey SECRET_KEY = new SecretKeySpec(new byte[1], "AES");
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetInstanceInvalidWrappingAlgorithm() {
+        JceMasterKey.getInstance(SECRET_KEY, "mockProvider", "mockKey",
+                "blatently/unsupported/algorithm");
+    }
+
+    /**
+     * Calls JceMasterKey.getInstance with differently cased wrappingAlgorithm names.
+     * Passes if no Exception is thrown.
+     * Relies on passing an invalid algorithm name to result in an Exception.
+     */
+    @Test
+    public void testGetInstanceCaseInsensitive() {
+        JceMasterKey.getInstance(SECRET_KEY, "mockProvider", "mockKey",
+                "aes/gcm/nopadding");
+        JceMasterKey.getInstance(SECRET_KEY, "mockProvider", "mockKey",
+                "AES/GCM/NoPadding");
+    }
+}


### PR DESCRIPTION
Algorithm names in the JCA spec are not case-sensitive. This makes
JceMasterKey algorithm names case insensitive.